### PR TITLE
fix:Switching tabs and returning will retrigger the request

### DIFF
--- a/hooks/useAgentChat.ts
+++ b/hooks/useAgentChat.ts
@@ -68,6 +68,7 @@ const useAgentChat = ({
         },
         body: JSON.stringify(parmas),
         signal: ctrl.signal,
+        openWhenHidden: true,
         async onopen(response) {
           if (history.length <= 1) {
             refreshDialogList();


### PR DESCRIPTION
bug解决：前端页面失焦(移出)后再移入会触发接口重复请求