### PR TITLE
set fixed height for text input

### DIFF
--- a/app/datastores/documents/page.tsx
+++ b/app/datastores/documents/page.tsx
@@ -430,7 +430,7 @@ const Documents = () => {
                       sx={{ marginBottom: '20px' }}
                     />
                     {t('Text')}:
-                    <Textarea onChange={(e: any) => setText(e.target.value)} minRows={4} sx={{ marginBottom: '20px' }} />
+                    <Textarea onChange={(e: any) => setText(e.target.value)} minRows={4} maxRows={4} sx={{ marginBottom: '20px' }} />
                   </>
                 )}
                 <Typography

--- a/app/datastores/page.tsx
+++ b/app/datastores/page.tsx
@@ -319,7 +319,7 @@ const Index = () => {
                       sx={{ marginBottom: '20px' }}
                     />
                     {t('Text')}:
-                    <Textarea onChange={(e: any) => setText(e.target.value)} minRows={4} sx={{ marginBottom: '20px' }} />
+                    <Textarea onChange={(e: any) => setText(e.target.value)} minRows={4} maxRows={4} sx={{ marginBottom: '20px' }} />
                   </>
                 )}
                 <Typography


### PR DESCRIPTION
Avoid the finish button being hidden by long text input.
![Snipaste_2023-09-05_15-26-08](https://github.com/eosphoros-ai/DB-GPT-Web/assets/47661973/fefafaa0-29ac-40d9-a86d-de0250f1782a)
