### PR TITLE
refactor: upgrade g2plot to g2 v5

### DIFF
--- a/components/chart/bar-chart.tsx
+++ b/components/chart/bar-chart.tsx
@@ -1,5 +1,5 @@
 import { ChartData } from '@/types/chat';
-import { Chart } from '@berryv/g2-rect';
+import { Chart } from '@berryv/g2-react';
 import { Card, CardContent, Typography } from '@mui/joy';
 
 export default function BarChart({ chart }: { key: string; chart: ChartData }) {
@@ -16,17 +16,14 @@ export default function BarChart({ chart }: { key: string; chart: ChartData }) {
           <div className="h-[300px]">
             <Chart
               options={{
-                type: 'interval',
                 autoFit: true,
+                height: 300,
+                type: 'interval',
                 data: chart.values,
                 encode: { x: 'name', y: 'value', color: 'type' },
-                legend: {
-                  position: 'bottom',
-                },
-                animation: {
-                  appear: {
-                    animation: 'wave-in',
-                    duration: 3000,
+                axis: {
+                  x: {
+                    labelAutoRotate: false,
                   },
                 },
               }}

--- a/components/chart/bar-chart.tsx
+++ b/components/chart/bar-chart.tsx
@@ -1,35 +1,8 @@
 import { ChartData } from '@/types/chat';
-import { Column } from '@antv/g2plot';
+import { Chart } from '@berryv/g2-rect';
 import { Card, CardContent, Typography } from '@mui/joy';
-import { useEffect, useRef } from 'react';
 
 export default function BarChart({ chart }: { key: string; chart: ChartData }) {
-  const ref = useRef(null);
-  const chartInstanceRef = useRef<{ chart: Column | null }>({ chart: null });
-  useEffect(() => {
-    if (ref.current) {
-      if (chartInstanceRef.current.chart) {
-        chartInstanceRef.current.chart.destroy();
-      }
-      chartInstanceRef.current.chart = new Column(ref.current, {
-        data: chart.values,
-        xField: 'name',
-        yField: 'value',
-        seriesField: 'type',
-        legend: {
-          position: 'bottom',
-        },
-        animation: {
-          appear: {
-            animation: 'wave-in',
-            duration: 3000,
-          },
-        },
-      });
-      chartInstanceRef.current.chart.render();
-    }
-  }, [chart.values]);
-
   return (
     <div className="flex-1 min-w-0">
       <Card className="h-full" sx={{ background: 'transparent' }}>
@@ -40,7 +13,25 @@ export default function BarChart({ chart }: { key: string; chart: ChartData }) {
           <Typography gutterBottom level="body3">
             {chart.chart_desc}
           </Typography>
-          <div className="h-[300px]" ref={ref}></div>
+          <div className="h-[300px]">
+            <Chart
+              options={{
+                type: 'interval',
+                autoFit: true,
+                data: chart.values,
+                encode: { x: 'name', y: 'value', color: 'type' },
+                legend: {
+                  position: 'bottom',
+                },
+                animation: {
+                  appear: {
+                    animation: 'wave-in',
+                    duration: 3000,
+                  },
+                },
+              }}
+            />
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/components/chart/bar-chart.tsx
+++ b/components/chart/bar-chart.tsx
@@ -15,9 +15,9 @@ export default function BarChart({ chart }: { key: string; chart: ChartData }) {
           </Typography>
           <div className="h-[300px]">
             <Chart
+              style={{ height: '100%' }}
               options={{
                 autoFit: true,
-                height: 300,
                 type: 'interval',
                 data: chart.values,
                 encode: { x: 'name', y: 'value', color: 'type' },

--- a/components/chart/line-chart.tsx
+++ b/components/chart/line-chart.tsx
@@ -1,7 +1,6 @@
 import { ChartData } from '@/types/chat';
 import { Card, CardContent, Typography } from '@mui/joy';
-import { useEffect, useRef } from 'react';
-import { Chart } from '@berryv/g2-rect';
+import { Chart } from '@berryv/g2-react';
 
 export default function LineChart({ chart }: { chart: ChartData }) {
   return (
@@ -18,33 +17,37 @@ export default function LineChart({ chart }: { chart: ChartData }) {
             <Chart
               options={{
                 autoFit: true,
+                height: 300,
                 type: 'view',
                 data: chart.values,
-                encode: {
-                  x: 'name',
-                  y: 'value',
-                  color: 'type',
-                  shape: 'smooth',
-                },
+
                 children: [
                   {
-                    type: 'interval',
-                    legend: {
-                      position: 'bottom',
+                    type: 'line',
+                    encode: {
+                      x: 'name',
+                      y: 'value',
+                      color: 'type',
+                      shape: 'smooth',
                     },
                   },
                   {
                     type: 'area',
+                    encode: {
+                      x: 'name',
+                      y: 'value',
+                      color: 'type',
+                      shape: 'smooth',
+                    },
                     legend: false,
                     style: {
                       fillOpacity: 0.15,
                     },
                   },
                 ],
-                animation: {
-                  appear: {
-                    animation: 'wave-in',
-                    duration: 3000,
+                axis: {
+                  x: {
+                    labelAutoRotate: false,
                   },
                 },
               }}

--- a/components/chart/line-chart.tsx
+++ b/components/chart/line-chart.tsx
@@ -20,7 +20,6 @@ export default function LineChart({ chart }: { chart: ChartData }) {
                 height: 300,
                 type: 'view',
                 data: chart.values,
-
                 children: [
                   {
                     type: 'line',

--- a/components/chart/line-chart.tsx
+++ b/components/chart/line-chart.tsx
@@ -15,9 +15,9 @@ export default function LineChart({ chart }: { chart: ChartData }) {
           </Typography>
           <div className="h-[300px]">
             <Chart
+              style={{ height: '100%' }}
               options={{
                 autoFit: true,
-                height: 300,
                 type: 'view',
                 data: chart.values,
                 children: [

--- a/components/chart/line-chart.tsx
+++ b/components/chart/line-chart.tsx
@@ -1,43 +1,9 @@
 import { ChartData } from '@/types/chat';
 import { Card, CardContent, Typography } from '@mui/joy';
 import { useEffect, useRef } from 'react';
-import { Line } from '@antv/g2plot';
+import { Chart } from '@berryv/g2-rect';
 
 export default function LineChart({ chart }: { chart: ChartData }) {
-  const chartRef = useRef(null);
-  const chartInstanceRef = useRef<{ chart: Line | null }>({ chart: null });
-
-  useEffect(() => {
-    if (chartRef.current) {
-      if (chartInstanceRef.current.chart) {
-        chartInstanceRef.current.chart.destroy();
-      }
-      chartInstanceRef.current.chart = new Line(chartRef.current, {
-        data: chart.values,
-        xField: 'name',
-        yField: 'value',
-        seriesField: 'type',
-        smooth: true,
-        // 配置折线趋势填充
-        area: {
-          style: {
-            fillOpacity: 0.15,
-          },
-        },
-        legend: {
-          position: 'bottom',
-        },
-        animation: {
-          appear: {
-            animation: 'wave-in',
-            duration: 3000,
-          },
-        },
-      });
-      chartInstanceRef.current.chart.render();
-    }
-  }, [chart.values]);
-
   return (
     <div className="flex-1 min-w-0">
       <Card className="h-full" sx={{ background: 'transparent' }}>
@@ -48,7 +14,42 @@ export default function LineChart({ chart }: { chart: ChartData }) {
           <Typography gutterBottom level="body3">
             {chart.chart_desc}
           </Typography>
-          <div className="h-[300px]" ref={chartRef}></div>
+          <div className="h-[300px]">
+            <Chart
+              options={{
+                autoFit: true,
+                type: 'view',
+                data: chart.values,
+                encode: {
+                  x: 'name',
+                  y: 'value',
+                  color: 'type',
+                  shape: 'smooth',
+                },
+                children: [
+                  {
+                    type: 'interval',
+                    legend: {
+                      position: 'bottom',
+                    },
+                  },
+                  {
+                    type: 'area',
+                    legend: false,
+                    style: {
+                      fillOpacity: 0.15,
+                    },
+                  },
+                ],
+                animation: {
+                  appear: {
+                    animation: 'wave-in',
+                    duration: 3000,
+                  },
+                },
+              }}
+            />
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@ant-design/icons": "^5.2.5",
     "@antv/g2": "^5.1.6",
-    "@berryv/g2-rect": "^0.2.0",
+    "@berryv/g2-react": "^0.1.0",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@monaco-editor/react": "^4.5.2",
     "@mui/icons-material": "^5.11.16",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@ant-design/icons": "^5.2.5",
-    "@antv/g2plot": "^2.4.31",
+    "@antv/g2": "^5.1.6",
+    "@berryv/g2-rect": "^0.2.0",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@monaco-editor/react": "^4.5.2",
     "@mui/icons-material": "^5.11.16",


### PR DESCRIPTION
- [x] g2plot -> g2 5.0
- [ ] test and debug

![image](https://github.com/eosphoros-ai/DB-GPT-Web/assets/7856674/43467b3f-9419-46d9-bd17-4721721413a3)


替换之后，使用新的版本，新的视觉样式，原 g2plot  还是使用旧的版本，维护力度也不够。另外，使用 ava 图表推荐，也需要使用新版本 g2 5.0，否则在 web 项目中就存在多个图表的版本。